### PR TITLE
Fix levelUp scope in game.js

### DIFF
--- a/game.js
+++ b/game.js
@@ -92,18 +92,8 @@ function newGame() {
   updateLevel(level);
   linesClearedTotal = 0;
   dropInterval = baseDropInterval;
-  
-   let gameSpeed = 1;
-
-  function levelUp(linesCleared) {
-    linesClearedTotal += linesCleared;
-    if (linesClearedTotal >= level * 10) {
-      level++;
-      gameSpeed = level;
-      dropInterval = baseDropInterval / gameSpeed;
-      updateLevel(level);
-    }
-  }
+  gameSpeed = 1;
+  levelUp(0);
 
   // Hide the game over screen and overlay
   gameOverElement.style.display = 'none';
@@ -123,6 +113,18 @@ let level = 1;
 const baseDropInterval = 1000; // In milliseconds
 
 let linesClearedTotal = 0;
+
+let gameSpeed = 1;
+
+function levelUp(linesCleared) {
+  linesClearedTotal += linesCleared;
+  if (linesClearedTotal >= level * 10) {
+    level++;
+    gameSpeed = level;
+    dropInterval = baseDropInterval / gameSpeed;
+    updateLevel(level);
+  }
+}
 
 
 const canvas = document.getElementById('gameBoard');


### PR DESCRIPTION
## Summary
- move `gameSpeed` and `levelUp` to global scope
- reset global `gameSpeed` and call `levelUp` from `newGame`
- `clearRows` now calls the global `levelUp`

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_6851ad8768248320af23c6048eaeff15