### PR TITLE
Add Jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Blocks Game
+
+This project contains a simple block game.
+
+## Running Tests
+
+Install dependencies with `npm install` and run all tests using:
+
+```bash
+npm test
+```

--- a/game.js
+++ b/game.js
@@ -44,6 +44,14 @@ function getCookie(name) {
   return null;
 }
 
+  if (typeof window !== 'undefined') {
+    window.setCookie = setCookie;
+    window.getCookie = getCookie;
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { setCookie, getCookie };
+  }
+
 // Function to save the high score
 function saveHighScore(email) {
   var highScore = getCookie(email);

--- a/game.test.js
+++ b/game.test.js
@@ -1,0 +1,18 @@
+const { setCookie, getCookie } = require('./game');
+
+describe('cookie helpers', () => {
+  beforeEach(() => {
+    // Reset document.cookie before each test
+    document.cookie = '';
+  });
+
+  test('setCookie stores value', () => {
+    setCookie('test', 'value', 1);
+    expect(document.cookie).toContain('test=value');
+  });
+
+  test('getCookie retrieves value', () => {
+    document.cookie = 'foo=bar';
+    expect(getCookie('foo')).toBe('bar');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "blocks",
+  "version": "1.0.0",
+  "description": "blocks game",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up Jest for the project
- expose `setCookie` and `getCookie` for testing
- add unit tests for cookie helpers
- document how to run tests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ad8c2668832098c31a41a2ae5b36