### PR TITLE
Use upload-pages-artifact in Pages workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v2
         with:
           # Upload entire repository
           path: '.'


### PR DESCRIPTION
## Summary
- update the GitHub Pages workflow to use `actions/upload-pages-artifact@v2`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68795006b0a083209f16fc293a8b1a43